### PR TITLE
Fix(Permissions): Old permission overwrites being overwritten

### DIFF
--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -23,12 +23,9 @@ class CategoryChannel extends GuildChannel {
             this.position = data.position;
         }
         if(data.permission_overwrites !== undefined) {
-            if(this.permissionOverwrites === undefined) {
-                this.permissionOverwrites = new Collection(PermissionOverwrite);
-            }
-            this.permissionOverwrites.clear();
+            this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
-                this.permissionOverwrites.update(overwrite);
+                this.permissionOverwrites.add(overwrite);
             });
         }
     }

--- a/lib/structures/MediaChannel.js
+++ b/lib/structures/MediaChannel.js
@@ -51,12 +51,9 @@ class MediaChannel extends GuildChannel {
             this.nsfw = data.nsfw;
         }
         if(data.permission_overwrites !== undefined) {
-            if(this.permissionOverwrites === undefined) {
-                this.permissionOverwrites = new Collection(PermissionOverwrite);
-            }
-            this.permissionOverwrites.clear();
+            this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
-                this.permissionOverwrites.update(overwrite);
+                this.permissionOverwrites.add(overwrite);
             });
         }
         if(data.position !== undefined) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -26,12 +26,9 @@ class TextChannel extends GuildTextableChannel {
             this.position = data.position;
         }
         if(data.permission_overwrites !== undefined) {
-            if(this.permissionOverwrites === undefined) {
-                this.permissionOverwrites = new Collection(PermissionOverwrite);
-            }
-            this.permissionOverwrites.clear();
+            this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
-                this.permissionOverwrites.update(overwrite);
+                this.permissionOverwrites.add(overwrite);
             });
         }
         if(data.nsfw !== undefined) {

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -30,12 +30,9 @@ class VoiceChannel extends GuildTextableChannel {
             this.position = data.position;
         }
         if(data.permission_overwrites !== undefined) {
-            if(this.permissionOverwrites === undefined) {
-                this.permissionOverwrites = new Collection(PermissionOverwrite);
-            }
-            this.permissionOverwrites.clear();
+            this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {
-                this.permissionOverwrites.update(overwrite);
+                this.permissionOverwrites.add(overwrite);
             });
         }
         if(data.nsfw !== undefined) {


### PR DESCRIPTION
Bsian's channel refactor included a change which changed how the `permission_overwrites` field is set. This made it so when `channelUpdate` was fired, `oldChannel.permissionOverwrites` would show the exact same overwrites as `channel.permissionOverwrites`.

Reverting this change so that our channel permission update logs work until Bsian figures out a proper way to fix it.